### PR TITLE
Fixed testHandleExtensionInitRequest

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -95,7 +95,7 @@ public class ExtensionsRunner {
         return objectMapper.readValue(file, ExtensionSettings.class);
     }
 
-    protected void setExtensionTransportService(TransportService extensionTransportService) {
+    void setExtensionTransportService(TransportService extensionTransportService) {
         this.extensionTransportService = extensionTransportService;
     }
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -95,6 +95,10 @@ public class ExtensionsRunner {
         return objectMapper.readValue(file, ExtensionSettings.class);
     }
 
+    protected void setExtensionTransportService(TransportService extensionTransportService) {
+        this.extensionTransportService = extensionTransportService;
+    }
+
     private void setUniqueId(String id) {
         this.uniqueId = id;
     }

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
 import java.net.InetAddress;
@@ -36,6 +37,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.extensions.DiscoveryExtension;
 import org.opensearch.discovery.InitializeExtensionsRequest;
+import org.opensearch.discovery.InitializeExtensionsResponse;
 import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
@@ -116,18 +118,19 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
                 null
             )
         );
+
+        // Set mocked transport service
+        extensionsRunner.setExtensionTransportService(this.transportService);
+        doNothing().when(this.transportService).connectToNode(sourceNode);
+
         InitializeExtensionsRequest extensionInitRequest = new InitializeExtensionsRequest(sourceNode, extensions);
-        /*
-         * NOT WORKING, can't establish outgoing connection to send API
-         *
+
         InitializeExtensionsResponse response = extensionsRunner.handleExtensionInitRequest(extensionInitRequest);
         // Test if name and unique ID are set
         assertEquals("sample-extension", response.getName());
         assertEquals("opensearch-sdk-1", extensionsRunner.getUniqueId());
         // Test if the source node is set after handleExtensionInitRequest() is called during OpenSearch bootstrap
         assertEquals(sourceNode, extensionsRunner.getOpensearchNode());
-         *
-         */
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -50,6 +50,8 @@ import org.opensearch.transport.Transport;
 
 public class TestExtensionsRunner extends OpenSearchTestCase {
 
+    private static final String EXTENSION_NAME = "sample-extension";
+
     private ExtensionsRunner extensionsRunner;
     private TransportService transportService;
 
@@ -107,7 +109,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
         );
         List<DiscoveryExtension> extensions = List.of(
             new DiscoveryExtension(
-                "sample-extension",
+                EXTENSION_NAME,
                 "opensearch-sdk-1",
                 "",
                 "",
@@ -127,7 +129,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
 
         InitializeExtensionsResponse response = extensionsRunner.handleExtensionInitRequest(extensionInitRequest);
         // Test if name and unique ID are set
-        assertEquals("sample-extension", response.getName());
+        assertEquals(EXTENSION_NAME, response.getName());
         assertEquals("opensearch-sdk-1", extensionsRunner.getUniqueId());
         // Test if the source node is set after handleExtensionInitRequest() is called during OpenSearch bootstrap
         assertEquals(sourceNode, extensionsRunner.getOpensearchNode());
@@ -137,7 +139,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     public void testHandleOpenSearchRequest() throws Exception {
 
         OpenSearchRequest request = new OpenSearchRequest(OpenSearchRequestType.REQUEST_OPENSEARCH_NAMED_WRITEABLE_REGISTRY);
-        assertEquals(extensionsRunner.handleOpenSearchRequest(request).getClass(), NamedWriteableRegistryResponse.class);
+        assertEquals(NamedWriteableRegistryResponse.class, extensionsRunner.handleOpenSearchRequest(request).getClass());
 
         // Add additional OpenSearch request handler tests here for each default extension point
     }


### PR DESCRIPTION
`extensionsRunner.handleExtensionInitRequest` invokes `extensionTransportService.connectToNode(sourceNode)` after returning the InitializeExtensionResponse. This is null because the `extensionRunner.extensionTransportService` is null until `extensionRunner.initializeExtensionTransportService` is invoked. For this test, we must set this transport service with our mock in order to circumnavigate the `connectToNode` invocation in order to test the response name, unique ID and opensearch node, so I created a protected setter for `extensionTransportService` in order to access this private field